### PR TITLE
fix mismatch in no.of secrets and accounts generated

### DIFF
--- a/packages/hardhat/scripts/generateAccountsFromSecrets.mjs
+++ b/packages/hardhat/scripts/generateAccountsFromSecrets.mjs
@@ -15,7 +15,7 @@ async function main() {
   }
 
   // Count the number of lines in the file
-  const ticketSecrets = secrets.split("\n");
+  const ticketSecrets = secrets.trim().split("\n");
   const numberOfSecrets = ticketSecrets.length;
   console.log("🔥 Generating " + numberOfSecrets + " new burner accounts...");
 

--- a/packages/hardhat/scripts/generateAccountsFromSecrets.mjs
+++ b/packages/hardhat/scripts/generateAccountsFromSecrets.mjs
@@ -23,7 +23,8 @@ async function main() {
   // and store the wallet address and private key in a json file
   const wallets = {};
   for (let i = 0; i < numberOfSecrets; i++) {
-    const generatedWallet = new Wallet(ethers.utils.keccak256(ethers.utils.toUtf8Bytes(ticketSecrets[i])));
+    const secretsWithoutTrailingSpaces = ticketSecrets[i].trim();
+    const generatedWallet = new Wallet(ethers.utils.keccak256(ethers.utils.toUtf8Bytes(secretsWithoutTrailingSpaces)));
     wallets[generatedWallet.address] = generatedWallet.privateKey;
   }
 

--- a/packages/hardhat/scripts/generateAccountsFromSecrets.mjs
+++ b/packages/hardhat/scripts/generateAccountsFromSecrets.mjs
@@ -16,13 +16,13 @@ async function main() {
 
   // Count the number of lines in the file
   const ticketSecrets = secrets.split("\n");
-  const amount = ticketSecrets.length - 1;
-  console.log("🔥 Generating " + amount + " new burner accounts...");
+  const numberOfSecrets = ticketSecrets.length;
+  console.log("🔥 Generating " + numberOfSecrets + " new burner accounts...");
 
   // Loop through walletSecrets and create a new wallet for each (using the value as a seed)
   // and store the wallet address and private key in a json file
   const wallets = {};
-  for (let i = 0; i < amount; i++) {
+  for (let i = 0; i < numberOfSecrets; i++) {
     const generatedWallet = new Wallet(ethers.utils.keccak256(ethers.utils.toUtf8Bytes(ticketSecrets[i])));
     wallets[generatedWallet.address] = generatedWallet.privateKey;
   }

--- a/packages/hardhat/scripts/generateAccountsFromSecrets.mjs
+++ b/packages/hardhat/scripts/generateAccountsFromSecrets.mjs
@@ -23,8 +23,8 @@ async function main() {
   // and store the wallet address and private key in a json file
   const wallets = {};
   for (let i = 0; i < numberOfSecrets; i++) {
-    const secretsWithoutTrailingSpaces = ticketSecrets[i].trim();
-    const generatedWallet = new Wallet(ethers.utils.keccak256(ethers.utils.toUtf8Bytes(secretsWithoutTrailingSpaces)));
+    const secretWithoutTrailingSpaces = ticketSecrets[i].trim();
+    const generatedWallet = new Wallet(ethers.utils.keccak256(ethers.utils.toUtf8Bytes(secretWithoutTrailingSpaces)));
     wallets[generatedWallet.address] = generatedWallet.privateKey;
   }
 


### PR DESCRIPTION
### Steps to reproduce: 
1. Rename ` ticket_secrets.csv.example` -> ` ticket_secrets.csv`
2. run `yarn generate-from-tickets`

![Screenshot 2023-06-14 at 10 27 13 AM](https://github.com/BuidlGuidl/event-wallet/assets/80153681/811a8148-b50e-4af7-9707-4b31ddcd9fa9)

Although we have 3 secrets it generates only two `accounts`. 

### Reason: 
we had initialized `const amount = ticketSecrets.length - 1` and in `for loop` we again doing  `i < amount`  it should have been either `i <= amount`. 

Don't know if `i < amount` was intended to handle any edge case while reading CSV and looping over it

Please feel free to nitpick for variable names or anything !!