### PR TITLE
Burner signer component with optional confirmation

### DIFF
--- a/packages/nextjs/components/scaffold-eth/BurnerSigner.tsx
+++ b/packages/nextjs/components/scaffold-eth/BurnerSigner.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { ethers } from "ethers";
+import { useAccount } from "wagmi";
+import { PencilSquareIcon } from "@heroicons/react/24/outline";
+import { Address } from "~~/components/scaffold-eth";
+import { useAutoConnect } from "~~/hooks/scaffold-eth";
+import { loadBurnerSK } from "~~/hooks/scaffold-eth";
+import scaffoldConfig from "~~/scaffold.config";
+
+type TSignature = {
+  signature: string;
+};
+
+interface IHandleSignature {
+  (arg0: TSignature): void;
+}
+
+type TBurnerSignerProps = {
+  children: React.ReactNode;
+  className: string;
+  disabled: boolean;
+  message: object;
+  handleSignature: IHandleSignature;
+  confirmation?: boolean;
+};
+
+export const BurnerSigner = ({
+  children,
+  className,
+  disabled,
+  message,
+  handleSignature,
+  confirmation,
+}: TBurnerSignerProps) => {
+  const [showModal, setShowModal] = useState<boolean>(false);
+  useAutoConnect();
+  const { address } = useAccount();
+
+  const handleSign = async () => {
+    try {
+      // Initialize Web3 provider
+      const burnerPK = loadBurnerSK();
+      const signer = new ethers.Wallet(burnerPK);
+
+      // Sign the message
+      const messageString = JSON.stringify(message);
+      const signature = await signer.signMessage(messageString);
+      setShowModal(false);
+      handleSignature({ signature });
+    } catch (e) {
+      console.log("Error signing: ", e);
+      return false;
+    }
+  };
+
+  const handleClick = async () => {
+    // If confirmation is undefined, use the scaffold config as default
+    if (confirmation === undefined) {
+      confirmation = scaffoldConfig?.burnerWallet?.signConfirmation;
+    }
+
+    if (confirmation) {
+      setShowModal(true);
+    } else {
+      handleSign();
+    }
+  };
+
+  return (
+    <div>
+      <button className={className} onClick={handleClick} disabled={!address || !message || disabled}>
+        {children}
+      </button>
+      <input
+        type="checkbox"
+        id="burner-signer-modal"
+        className="modal-toggle"
+        checked={showModal}
+        onChange={() => setShowModal(!showModal)}
+      />
+      <label htmlFor="burner-signer-modal" className="modal cursor-pointer">
+        <label className="max-w-2xl modal-box relative">
+          {/* dummy input to capture event onclick on modal box */}
+          <input className="h-0 w-0 absolute top-0 left-0" />
+          <h3 className="text-xl font-bold mb-3">Sign Message</h3>
+          <label className="btn btn-ghost btn-sm btn-circle absolute right-3 top-3" onClick={() => setShowModal(false)}>
+            ✕
+          </label>
+          <div className="space-y-3">
+            <div className="flex flex-col place-items-center space-y-3">
+              <span className="text-sm font-bold">Address</span>
+              <Address address={address} />
+            </div>
+            <div className="flex flex-col space-y-3">
+              <span className="text-sm font-bold">Message To Sign</span>
+              <code className="text-left">
+                <pre>{JSON.stringify(message, null, 2)}</pre>
+              </code>
+            </div>
+            <div className="flex flex-row-reverse items-end space-y-3">
+              <button className={`h-10 btn btn-primary btn-sm px-2 rounded-full`} onClick={handleSign}>
+                <PencilSquareIcon className="h-6 w-6" />
+                <span>Sign Message</span>
+              </button>
+              <button className={`h-10 btn btn-sm px-2 rounded-full mr-3`} onClick={() => setShowModal(false)}>
+                <span>Cancel</span>
+              </button>
+            </div>
+          </div>
+        </label>
+      </label>
+    </div>
+  );
+};

--- a/packages/nextjs/components/screens/QuestionShow.tsx
+++ b/packages/nextjs/components/screens/QuestionShow.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useInterval } from "usehooks-ts";
 import { useAccount } from "wagmi";
 import { BurnerSigner } from "~~/components/scaffold-eth/BurnerSigner";
@@ -29,7 +29,7 @@ export const QuestionShow = () => {
     option: selectedOption,
   };
 
-  const fetchQuestionStatus = async () => {
+  const fetchQuestionStatus = useCallback(async () => {
     try {
       const response = await fetch(`/api/questions/${id}`, {
         method: "GET",
@@ -53,7 +53,7 @@ export const QuestionShow = () => {
     } finally {
       setLoadingQuestionStatus(false);
     }
-  };
+  }, [id]);
 
   useEffect(() => {
     (async () => {
@@ -61,7 +61,7 @@ export const QuestionShow = () => {
         await fetchQuestionStatus();
       }
     })();
-  }, [question]);
+  }, [question, fetchQuestionStatus]);
 
   useInterval(async () => {
     if (questionStatus !== "reveal") {

--- a/packages/nextjs/pages/admin/questions/[id]/index.tsx
+++ b/packages/nextjs/pages/admin/questions/[id]/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { NextPage } from "next";
@@ -32,7 +32,7 @@ const AdminQuestionShow: NextPage = () => {
 
   const aliases = useAliases({});
 
-  const fetchQuestionData = async () => {
+  const fetchQuestionData = useCallback(async () => {
     try {
       const response = await fetch(`/api/questions/${id}`, {
         method: "GET",
@@ -54,7 +54,7 @@ const AdminQuestionShow: NextPage = () => {
     } finally {
       setLoadingQuestionData(false);
     }
-  };
+  }, [id]);
 
   useEffect(() => {
     (async () => {
@@ -62,7 +62,7 @@ const AdminQuestionShow: NextPage = () => {
         await fetchQuestionData();
       }
     })();
-  }, [question]);
+  }, [question, fetchQuestionData]);
 
   useInterval(async () => {
     if (questionStatus !== "reveal") {

--- a/packages/nextjs/pages/api/check-in.ts
+++ b/packages/nextjs/pages/api/check-in.ts
@@ -17,8 +17,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
   let recoveredAddress: string;
   try {
-    // The message is just the signer address
-    recoveredAddress = verifyMessage(signerAddress, signature);
+    const message = JSON.stringify({ action: "user-checkin", address: signerAddress });
+    recoveredAddress = verifyMessage(message, signature);
   } catch (error) {
     res.status(400).json({ error: "Error recovering the signature" });
     return;

--- a/packages/nextjs/pages/api/questions/[id]/index.ts
+++ b/packages/nextjs/pages/api/questions/[id]/index.ts
@@ -26,8 +26,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     let recoveredAddress: string;
     try {
-      // The message is the option
-      recoveredAddress = verifyMessage(option, signature);
+      const message = JSON.stringify({ action: "question-answer", questionId: id, option });
+      recoveredAddress = verifyMessage(message, signature);
     } catch (error) {
       res.status(400).json({ error: "Error recovering the signature" });
       return;

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import Head from "next/head";
 import Image from "next/image";
 import type { NextPage } from "next";
@@ -52,7 +52,7 @@ const Home: NextPage = () => {
     args: [address],
   });
 
-  const updateUserData = async () => {
+  const updateUserData = useCallback(async () => {
     try {
       setLoadingUserData(true);
       const response = await fetch(`/api/users/${address}`, {
@@ -71,13 +71,13 @@ const Home: NextPage = () => {
     } finally {
       setLoadingUserData(false);
     }
-  };
+  }, [address]);
 
   useEffect(() => {
     if (address) {
       updateUserData();
     }
-  }, [address]);
+  }, [address, updateUserData]);
 
   const screenRender = screens[screen];
 

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -20,7 +20,6 @@ import { QuestionShow } from "~~/components/screens/QuestionShow";
 import { useAutoConnect, useScaffoldContractRead } from "~~/hooks/scaffold-eth";
 import { useAppStore } from "~~/services/store/store";
 import { UserData } from "~~/types/question";
-import { notification } from "~~/utils/scaffold-eth";
 
 const screens = {
   main: <Main />,
@@ -63,13 +62,9 @@ const Home: NextPage = () => {
         },
       });
 
-      const data = await response.json();
-
       if (response.ok) {
+        const data = await response.json();
         setUserData(data);
-      } else {
-        const result = await response.json();
-        notification.error(result.error);
       }
     } catch (e) {
       console.log("Error getting user data", e);

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -11,6 +11,7 @@ export type ScaffoldConfig = {
   burnerWallet: {
     enabled: boolean;
     onlyLocal: boolean;
+    signConfirmation: boolean;
   };
   walletAutoConnect: boolean;
 };
@@ -39,6 +40,7 @@ const scaffoldConfig = {
     enabled: true,
     // Only show the Burner Wallet when running on hardhat network
     onlyLocal: false,
+    signConfirmation: true,
   },
 
   /**


### PR DESCRIPTION
Add a BurnerSigner component to show a modal with the signing data and a confirmation button. 

It can be configured at app level on scaffold.config.ts or every time the component is used (if no confirmation setting is used at the component level, the app default is used).

Example usage:

`<BurnerSigner
          className="btn btn-primary"
          disabled={processing || loadingCheckedIn || checkedIn}
          message={message}
          handleSignature={handleSignature}
          confirmation={true}
        >
          {loadingCheckedIn ? "..." : checkedIn ? "Checked-in" : "Check-in"}
        </BurnerSigner>`

The component children content is used as the button content.

**className** and **disabled** are used at the button too.

**message** is the message to sign.

**handleSignature** is the function to call after the user confirms the signing

**confirmation** is an optional parameter to show or not the confirmation modal.

The confirmation modal looks like:

![localhost_3000_ (15)](https://github.com/BuidlGuidl/event-wallet/assets/466652/ebed74b5-b2dd-4b28-94af-8f063fca72e3)

closes #53 