### PR TITLE
Add New Scripts & Update Previous

### DIFF
--- a/packages/hardhat/contracts/DisperseFunds.sol
+++ b/packages/hardhat/contracts/DisperseFunds.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.17;
+pragma solidity 0.8.19;
 
 // hardhat 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";

--- a/packages/hardhat/scripts/dex-trader/generateBurnerAccount.ts
+++ b/packages/hardhat/scripts/dex-trader/generateBurnerAccount.ts
@@ -1,0 +1,39 @@
+import { ethers } from "ethers";
+import { parse, stringify } from "envfile";
+import * as fs from "fs";
+
+const envFilePath = "./.env";
+
+/**
+ * Generate a new random private key and write it to the .env file
+ * @param existingEnvConfig
+ */
+const setNewEnvConfig = (name: string, existingEnvConfig = {}) => {
+  console.log("👛 Generating new burner wallet");
+  const randomWallet = ethers.Wallet.createRandom();
+
+  const newEnvConfig = {
+    ...existingEnvConfig,
+    [name]: randomWallet.privateKey,
+  };
+
+  // Store in .env
+  fs.writeFileSync(envFilePath, stringify(newEnvConfig));
+  console.log("📄 Private Key saved to packages/hardhat/.env file");
+
+  return randomWallet;
+};
+
+async function generateBurner(name: string) {
+  if (!fs.existsSync(envFilePath)) {
+    // No .env file yet.
+    return setNewEnvConfig(name);
+  }
+
+  // .env file exists
+  const existingEnvConfig = parse(fs.readFileSync(envFilePath).toString());
+
+  return setNewEnvConfig(name, existingEnvConfig);
+}
+
+export { generateBurner };

--- a/packages/hardhat/scripts/dex-trader/prepBurnerTraders.ts
+++ b/packages/hardhat/scripts/dex-trader/prepBurnerTraders.ts
@@ -1,0 +1,79 @@
+import { ethers } from "ethers";
+import dotenv from "dotenv";
+import { generateBurner } from "./generateBurnerAccount";
+import deployedContracts from "./deployedContracts";
+dotenv.config();
+
+interface TokenInfo {
+  name: string;
+  dexAddr: string;
+  tokenAddr: string;
+  tokenAbi: any;
+}
+
+const saltAddr = deployedContracts[100][0]["contracts"]["SaltToken"]["address"];
+const saltAbi = deployedContracts[100][0]["contracts"]["SaltToken"]["abi"];
+
+// import rpc, deployer pk
+const gnosisRpc = process.env.GNOSIS_RPC!;
+const privateKey = process.env.DEPLOYER_PRIVATE_KEY!;
+
+const provider = new ethers.providers.JsonRpcProvider(gnosisRpc);
+const deployerWallet = new ethers.Wallet(privateKey, provider);
+
+// number of tokens & amount of xDai to send to burner wallets
+const tokenAmount = "1";
+const xDaiAmount = "0.001";
+
+// set up contract instances
+
+// create burner wallet\
+async function prepBurner(tokenInfo: TokenInfo) {
+  const traderWallet = await generateBurner(tokenInfo.name);
+  const saltContract = new ethers.Contract(saltAddr, saltAbi, deployerWallet);
+  const tokenContract = new ethers.Contract(tokenInfo.tokenAddr, tokenInfo.tokenAbi, deployerWallet);
+
+  const traderAddr = traderWallet.address;
+  // send XDAI
+  const sendXDai = await deployerWallet.sendTransaction({
+    to: traderAddr,
+    value: ethers.utils.parseEther(xDaiAmount),
+  });
+
+  // send SALT/TOKEN
+  const sendSalt = await saltContract.transfer(traderAddr, ethers.utils.parseEther(tokenAmount));
+  const sendToken = await tokenContract.transfer(traderAddr, ethers.utils.parseEther(tokenAmount));
+
+  console.log(`${sendXDai}, ${sendSalt}, ${sendToken} COMPLETE`);
+  console.log(`XDAI/SALT/${tokenInfo.name} sent to ${traderAddr}`);
+}
+
+const AvocadoInfo: TokenInfo = {
+  name: "AVOCADO",
+  dexAddr: deployedContracts[100][0]["contracts"]["BasicDexAvocado"]["address"],
+  tokenAddr: deployedContracts[100][0]["contracts"]["AvocadoToken"]["address"],
+  tokenAbi: deployedContracts[100][0]["contracts"]["AvocadoToken"]["abi"],
+};
+
+const BananaInfo: TokenInfo = {
+  name: "BANANA",
+  dexAddr: deployedContracts[100][0]["contracts"]["BasicDexBanana"]["address"],
+  tokenAddr: deployedContracts[100][0]["contracts"]["BananaToken"]["address"],
+  tokenAbi: deployedContracts[100][0]["contracts"]["BananaToken"]["abi"],
+};
+
+const TomatoInfo: TokenInfo = {
+  name: "TOMATO",
+  dexAddr: deployedContracts[100][0]["contracts"]["BasicDexTomato"]["address"],
+  tokenAddr: deployedContracts[100][0]["contracts"]["TomatoToken"]["address"],
+  tokenAbi: deployedContracts[100][0]["contracts"]["TomatoToken"]["abi"],
+};
+
+async function batchPrepBurners() {
+  const prepAvocado = await prepBurner(AvocadoInfo);
+  const prepBanana = await prepBurner(BananaInfo);
+  const prepTomato = await prepBurner(TomatoInfo);
+  console.log(`${prepAvocado}, ${prepBanana}, ${prepTomato} COMPLETE`);
+}
+
+batchPrepBurners();

--- a/packages/hardhat/scripts/dex-trader/tradeDex.ts
+++ b/packages/hardhat/scripts/dex-trader/tradeDex.ts
@@ -1,0 +1,102 @@
+import { ethers } from "ethers";
+import dotenv from "dotenv";
+dotenv.config();
+
+import deployedContracts from "./deployedContracts";
+
+if (process.argv.length != 3) {
+  console.log("Input dex to trade, example:");
+  console.log("ts-node tradeDex.ts 0");
+  process.exit();
+}
+
+const gnosisRpc = process.env.GNOSIS_RPC!;
+const dexChoice = Number(process.argv[2]);
+
+const saltAbi = deployedContracts[100][0]["contracts"]["SaltToken"]["abi"];
+const saltAddr = deployedContracts[100][0]["contracts"]["SaltToken"]["address"];
+let dexAddr: string;
+let dexAbi, tokenAddr, privateKey;
+
+if (dexChoice == 0) {
+  // avocado
+  dexAddr = deployedContracts[100][0]["contracts"]["BasicDexAvocado"]["address"];
+  dexAbi = deployedContracts[100][0]["contracts"]["BasicDexAvocado"]["abi"];
+  tokenAddr = deployedContracts[100][0]["contracts"]["AvocadoToken"]["address"];
+  privateKey = process.env.AVOCADO;
+} else if (dexChoice == 1) {
+  // banana
+  dexAddr = deployedContracts[100][0]["contracts"]["BasicDexBanana"]["address"];
+  dexAbi = deployedContracts[100][0]["contracts"]["BasicDexBanana"]["abi"];
+  tokenAddr = deployedContracts[100][0]["contracts"]["BananaToken"]["address"];
+  privateKey = process.env.BANANA;
+} else {
+  // tomato
+  dexAddr = deployedContracts[100][0]["contracts"]["BasicDexTomato"]["address"];
+  dexAbi = deployedContracts[100][0]["contracts"]["BasicDexTomato"]["abi"];
+  tokenAddr = deployedContracts[100][0]["contracts"]["TomatoToken"]["address"];
+  privateKey = process.env.TOMATO;
+}
+
+if (!privateKey) {
+  console.log("No trader PK found, run prepBurnerTraders.ts first");
+  process.exit();
+}
+
+const tradeFrequency = 10_000; // 10 seconds
+
+const provider = new ethers.providers.JsonRpcProvider(gnosisRpc);
+const wallet = new ethers.Wallet(privateKey, provider);
+
+const saltContract = new ethers.Contract(saltAddr, saltAbi, wallet);
+const tokenContract = new ethers.Contract(tokenAddr, saltAbi, wallet);
+
+const tradeWeights = [0.1, 0.25, 0.5, 0.75, 0.9];
+const blocksBeforeSwitch = [5, 10, 15, 25];
+let tradeWeight = tradeWeights[Math.floor(Math.random() * tradeWeights.length)];
+let switchTimer = blocksBeforeSwitch[Math.floor(Math.random() * blocksBeforeSwitch.length)];
+const txSizes = ["0.01", "0.02", "0.04", "0.08", "0.1"];
+
+let count = 0;
+
+console.log("Starting trades");
+console.log("Initial trade weight:", tradeWeight);
+console.log("Blocks til next switch:", switchTimer);
+const assetDexContract = new ethers.Contract(dexAddr, dexAbi, wallet);
+
+console.log(wallet.address);
+
+async function approveDex() {
+  const approveSalt = await saltContract.approve(dexAddr, ethers.constants.MaxUint256);
+  const approveToken = await tokenContract.approve(dexAddr, ethers.constants.MaxUint256);
+  console.log(`${approveSalt}, ${approveToken} COMPLETE`);
+}
+
+async function makeTx() {
+  const randSize = Math.floor(Math.random() * txSizes.length);
+  // const currentBlock = await provider.getBlockNumber();
+  count++;
+  console.log("Current count", count);
+  if (count % switchTimer == 0) {
+    tradeWeight = tradeWeights[Math.floor(Math.random() * tradeWeights.length)];
+    switchTimer = blocksBeforeSwitch[Math.floor(Math.random() * blocksBeforeSwitch.length)];
+    count = 0;
+    console.log("Changing trade strategy");
+    console.log("New trade weight:", tradeWeight);
+    console.log("Blocks til next switch:", switchTimer);
+  }
+
+  if (Math.random() >= tradeWeight) {
+    // buy credit
+    const tx = await assetDexContract.assetToCredit(ethers.utils.parseEther(txSizes[randSize]), BigInt(0));
+    tx.wait();
+    console.log("Credit purchase complete");
+  } else {
+    // buy asset
+    const tx = await assetDexContract.creditToAsset(ethers.utils.parseEther(txSizes[randSize]), BigInt(0));
+    tx.wait();
+    console.log("Asset purchase complete");
+  }
+}
+approveDex();
+setInterval(makeTx, tradeFrequency);


### PR DESCRIPTION
**DisperseFunds.sol**
Update pragma to 0.8.19 to match the current hardhat config

**disperseFunds.ts**
Added logic where the deployer funds the contract with XDAI & SALT before attempting to disperse funds.

**generateBurnerAccount.ts**
Creates a burner address.
Stores the private key in the .env file as ${TOKEN_NAME}=PRIVATE_KEY

**prepBurnerTrader.ts**
Calls generateBurnerAccount once for each token.
Sends the addresses some xDAI/SALT/TOKEN.

**tradeDex.ts**
Takes a command line argument to know which dex to trade 0/1/2.
Max approves salt/token for the burner address made in prepBurnerTrader.ts.
Buys/Sells with a random weight for a random number of blocks before changing it's trade weight again.

